### PR TITLE
Update `siobrultech-protocols` to v0.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-siobrultech-protocols==0.1.1
+siobrultech-protocols==0.2.0


### PR DESCRIPTION
[This version](https://github.com/sdwilsh/siobrultech-protocols/releases/tag/v0.2.0) fixed a typing error of `Packet.polarized_watt_seconds`.

No behavior changes here, but if you have type checking enabled (like via pylance), you'll start getting errors.